### PR TITLE
Fix Context Managers examples

### DIFF
--- a/python.rst
+++ b/python.rst
@@ -2074,10 +2074,10 @@ If we were writing a Python module to write TeX, we might do something like this
 the environments are closed properly::
 
   >>> def start(env):
-  ...     return '\begin{}'.format(env)
+  ...     return '\\begin{{{}}}'.format(env)
 
   >>> def end(env):
-  ...      return '\end{}'.format(env)
+  ...      return '\\end{{{}}}'.format(env)
 
   >>> def may_error():
   ...     import random
@@ -2102,18 +2102,18 @@ Function Based Context Managers
 -------------------------------
 
 To create a context manager with a function, decorate with
-``contextlib.contextmanager``, and yield where you want to bookend::
+``contextlib.contextmanager``, and yield where you want to insert your block::
 
   >>> import contextlib
   >>> @contextlib.contextmanager
   ... def env(name, content):
-  ...     content.append(r'\begin{}'.format(name))
+  ...     content.append('\\begin{{{}}}'.format(name))
   ...     try:
   ...         yield
   ...     except ValueError:
   ...         pass
   ...     finally:
-  ...         content.append(r'\end{}'.format(name))
+  ...         content.append('\\end{{{}}}'.format(name))
 
 Our code looks better now, and there will always be a closing tag::
 
@@ -2122,7 +2122,7 @@ Our code looks better now, and there will always be a closing tag::
   ...     out.append(may_error())
 
   >>> out
-  ['\\begincenter', 'content', '\\endcenter']
+  ['\\begin{center}', 'content', '\\end{center}']
 
 Class Based Context Managers
 ----------------------------
@@ -2135,14 +2135,14 @@ To create a class based context manager, implement the ``__enter__`` and ``__exi
   ...         self.content = content
   ...
   ...     def __enter__(self):
-  ...         self.content.append(r'\begin{}'.format(
+  ...         self.content.append('\\begin{{{}}}'.format(
   ...             self.name))
   ...
   ...     def __exit__(self, type, value, tb):
   ...         # if error in block, t, v, & tb
   ...         # have non None values
   ...         # return True to hide exception
-  ...         self.content.append(r'\end{}'.format(
+  ...         self.content.append('\\end{{{}}}'.format(
   ...             self.name))
   ...         return True
 
@@ -2153,7 +2153,7 @@ The code looks the same as using the function based context manager::
   ...     out.append(may_error())
 
   >>> out  # may_error had an issue
-  ['\\begincenter', '\\endcenter']
+  ['\\begin{center}', '\\end{center}']
 
 
 Context objects


### PR DESCRIPTION
`\begincenter` and  `\endcenter` don't exist in LaTeX and the example code does not produce the expected result due to missing escape sequences for the backslash and curly braces. The example changes once you switch to raw strings, where backslashes do not need to be escaped, but curly braces still do.

I have fixed the strings and outputs, and changed the 2nd and 3rd example to use simple strings instead of raw strings. Readers may not catch that the switch happens which adds to confusion since backslashes need to be escaped in simple strings, but not in raw strings.

You also may want to consider adding a note, that even through the output will display two backslashes, the actual string only has one backslash. 

Finally the `may_error()` part could become very confusing, especially when people execute the code and get different results from the ones you printed and, even worse, potentially varying results if they run the example multiple times.