### PR TITLE
Rename duplicate table titles for the Tuple and Set chapters

### DIFF
--- a/python.rst
+++ b/python.rst
@@ -590,7 +590,7 @@ We can access members by position or name (name allows us to be more explicit)::
 
 ..  longtable: format: {>{\hangindent=1em\hangafter=1\raggedright\arraybackslash }p{.3\textwidth} l >{\hangindent=1em\hangafter=1\raggedright\arraybackslash }p{.3\textwidth}}
 
-.. table:: Tuple Methods
+.. table:: Tuple Operations
   
   ================================== ========================= ============================================================
   Operation                          Provided                  Result
@@ -675,7 +675,7 @@ Sets are useful because they provide *set operations*, such as union
 
 ..  longtable: format: {>{\hangindent=1em\hangafter=1\raggedright\arraybackslash }p{.25\textwidth} l >{\hangindent=1em\hangafter=1\raggedright\arraybackslash }p{.35\textwidth}}
 
-.. table:: Set Methods
+.. table:: Set Operations
   
   ======================================= ========================= ============================================================
   Operation                               Provided By               Result


### PR DESCRIPTION
 * Changed the title of the tables pertaining to operations to end with "**Operations**" instead of "**Methods**".
 * Although some chapters refer to these as "**Magic Method**s" others refer to them as "**Operations**". I went with the latter.